### PR TITLE
Fix compilation warnings: "… will be initialized after [-Wreorder]"

### DIFF
--- a/src/qdeferreddata.hpp
+++ b/src/qdeferreddata.hpp
@@ -192,9 +192,9 @@ private:
 
 template<class ...Types>
 QDeferredData<Types...>::QDeferredData() :
-	m_mutex(QMutex::Recursive),
+	m_blockingEventLoop(nullptr),
 	m_state(QDeferredState::PENDING),
-	m_blockingEventLoop(nullptr)
+	m_mutex(QMutex::Recursive)
 {
 	// NOTE : compiling below or in init list m_finishedFunction(nullptr)
 	//        randomly fails to compile

--- a/src/qlambdathreadworkerdata.cpp
+++ b/src/qlambdathreadworkerdata.cpp
@@ -86,8 +86,8 @@ QLambdaThreadWorkerData::QLambdaThreadWorkerData()
 
 QLambdaThreadWorkerData::QLambdaThreadWorkerData(const QLambdaThreadWorkerData &other) : 
 	QSharedData(other),
-	mp_workerObj   (other.mp_workerObj   ),
 	mp_workerThread(other.mp_workerThread),
+	mp_workerObj   (other.mp_workerObj   ),
 	m_strThreadId  (other.m_strThreadId  ),
 	m_intIdCounter (other.m_intIdCounter ),
 	m_requestedQuit(other.m_requestedQuit)


### PR DESCRIPTION
These compilation warnings happen (at least) with: `gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0` and
```
QMake version 3.1
Using Qt version 5.15.2 in /usr/lib/x86_64-linux-gnu
```
